### PR TITLE
chore: bump terraform-skill external plugin to v1.9.0

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -21,7 +21,7 @@
       "source": {
         "source": "url",
         "url": "git@github.com:antonbabenko/terraform-skill.git",
-        "ref": "v1.8.0"
+        "ref": "v1.9.0"
       },
       "policy": {
         "installation": "AVAILABLE",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,7 +15,7 @@
       "source": {
         "source": "github",
         "repo": "antonbabenko/terraform-skill",
-        "ref": "v1.8.0"
+        "ref": "v1.9.0"
       },
       "description": "Use when writing, reviewing, or debugging Terraform/OpenTofu modules, tests, CI, scans, or state ops - diagnoses failure mode (identity churn, secrets, blast radius, CI drift, state corruption) with version-aware guards.",
       "category": "development",
@@ -32,7 +32,7 @@
         "lsp",
         "terraform-ls"
       ],
-      "version": "1.8.0"
+      "version": "1.9.0"
     },
     {
       "name": "code-intelligence",


### PR DESCRIPTION
Points both marketplace manifests (.claude-plugin + .agents/plugins Codex) at terraform-skill **v1.9.0** (was v1.8.0), so the umbrella marketplace serves the current release. Prerequisite for decommissioning terraform-skill's own marketplace.

- `.claude-plugin/marketplace.json`: terraform-skill `source.ref` + mirrored `version` 1.8.0 -> 1.9.0
- `.agents/plugins/marketplace.json`: terraform-skill `source.ref` 1.8.0 -> 1.9.0 (no version field; unchanged)
- code-intelligence + all other fields untouched

Manifest-only (no `plugins/` content), `chore:` subject -> no release per path-based detection.