### PR TITLE
chore: bump terraform-skill external plugin to v1.10.0

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -21,7 +21,7 @@
       "source": {
         "source": "url",
         "url": "git@github.com:antonbabenko/terraform-skill.git",
-        "ref": "v1.9.0"
+        "ref": "v1.10.0"
       },
       "policy": {
         "installation": "AVAILABLE",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,7 +15,7 @@
       "source": {
         "source": "github",
         "repo": "antonbabenko/terraform-skill",
-        "ref": "v1.9.0"
+        "ref": "v1.10.0"
       },
       "description": "Use when writing, reviewing, or debugging Terraform/OpenTofu modules, tests, CI, scans, or state ops - diagnoses failure mode (identity churn, secrets, blast radius, CI drift, state corruption) with version-aware guards.",
       "category": "development",
@@ -32,7 +32,7 @@
         "lsp",
         "terraform-ls"
       ],
-      "version": "1.9.0"
+      "version": "1.10.0"
     },
     {
       "name": "code-intelligence",


### PR DESCRIPTION
Pin both manifests to terraform-skill **v1.10.0** (the post-decommission release; skill content identical to v1.9.0). Keeps the single umbrella marketplace current. Manifest-only, no release.