### PR TITLE
feat(code-intelligence): name terraform-skill as a domain-skill example

### DIFF
--- a/plugins/code-intelligence/skills/code-intelligence/SKILL.md
+++ b/plugins/code-intelligence/skills/code-intelligence/SKILL.md
@@ -11,7 +11,9 @@ metadata:
 
 Pick the search tool by task, not by habit. Generic and language-agnostic;
 domain skills extend it with server capability matrices and ecosystem
-prerequisites. It is model-triggered guidance, not enforcement.
+prerequisites - for example the `terraform-skill` plugin (same marketplace)
+owns the terraform-ls capability matrix and Terraform setup. It is
+model-triggered guidance, not enforcement.
 
 ## Tool Precedence
 


### PR DESCRIPTION
## What
Symmetric soft cross-reference for zero-glue discovery. The generic `code-intelligence` SKILL.md already says "domain skills extend it"; this names `terraform-skill` (same marketplace) as the concrete example owning the terraform-ls capability matrix and setup.

## Why
Completes the bidirectional Protocol/Provider link: a user with the generic plugin working in Terraform is pointed to the domain plugin. Plugin stays language-agnostic (one example, not Terraform-specific content). Confidentiality: no private terms (scanned).

## Companion PRs
- antonbabenko/terraform-skill: Provider side (cross-ref + setup)