### PR TITLE
chore(external-plugins): update external plugin pins

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -21,7 +21,7 @@
       "source": {
         "source": "url",
         "url": "git@github.com:antonbabenko/terraform-skill.git",
-        "ref": "v1.10.0"
+        "ref": "v1.11.0"
       },
       "policy": {
         "installation": "AVAILABLE",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,7 +15,7 @@
       "source": {
         "source": "github",
         "repo": "antonbabenko/terraform-skill",
-        "ref": "v1.10.0"
+        "ref": "v1.11.0"
       },
       "description": "Use when writing, reviewing, or debugging Terraform/OpenTofu modules, tests, CI, scans, or state ops - diagnoses failure mode (identity churn, secrets, blast radius, CI drift, state corruption) with version-aware guards.",
       "category": "development",
@@ -32,7 +32,7 @@
         "lsp",
         "terraform-ls"
       ],
-      "version": "1.10.0"
+      "version": "1.11.0"
     },
     {
       "name": "code-intelligence",


### PR DESCRIPTION
Automated external-plugin pin update (first run; PR opened manually because the repo's 'Allow GitHub Actions to create PRs' setting was off - now enabled, future scheduled runs self-open).

Bumps terraform-skill **v1.10.0 -> v1.11.0** (latest upstream release): `source.ref` in both manifests + mirrored `.claude-plugin` `version`. Manifest-only `chore:` - no agent-plugins release.