### PR TITLE
fix(code-intelligence): doctor prints claude-code-lsps install path

### DIFF
--- a/plugins/code-intelligence/commands/doctor.md
+++ b/plugins/code-intelligence/commands/doctor.md
@@ -55,6 +55,13 @@ themselves.
 | Terraform | `terraform-ls` | `brew install hashicorp/tap/terraform-ls` |
 | Lua | `lua-language-server` | `brew install lua-language-server` |
 
+**Claude Code users:** several language servers are also installable as LSP
+plugins from the `claude-code-lsps` marketplace, no manual binary needed -
+`/plugin marketplace add boostvolt/claude-code-lsps` then
+`/plugin install <server>@claude-code-lsps` (e.g.
+`terraform-ls@claude-code-lsps`). Prefer this on Claude Code; fall back to the
+binary install hints above otherwise.
+
 ## 4. Verdict
 
 - `rg` present AND at least one language server present -> print `READY`.


### PR DESCRIPTION
`code-intelligence:doctor` only emitted per-language binary install hints. Adds a generic Claude Code note after the language-server table: install servers as LSP plugins via `boostvolt/claude-code-lsps` (`/plugin install <server>@claude-code-lsps`, e.g. `terraform-ls@claude-code-lsps`), preferred on Claude Code; binary hints stay the fallback. Generic/language-agnostic; install guidance lives in the doctor command, not SKILL.md/references.