### PR TITLE
ci: auto-merge the external-plugin update PR

### DIFF
--- a/.github/workflows/update-external-plugins.yml
+++ b/.github/workflows/update-external-plugins.yml
@@ -79,6 +79,7 @@ jobs:
           EOF
 
       - name: Open PR
+        id: cpr
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
         with:
           branch: automation/external-plugin-updates
@@ -98,3 +99,18 @@ jobs:
           add-paths: |
             .claude-plugin/marketplace.json
             .agents/plugins/marketplace.json
+
+      - name: Auto-merge
+        # The inline "Validate manifest sync" step above is the gate: if it
+        # fails the workflow stops and no PR exists. Manifest-only chore PR
+        # -> no agent-plugins release. Squash-merge immediately.
+        if: >-
+          ${{ steps.cpr.outputs.pull-request-number != '' &&
+              (steps.cpr.outputs.pull-request-operation == 'created' ||
+               steps.cpr.outputs.pull-request-operation == 'updated') }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ steps.cpr.outputs.pull-request-number }}
+        run: |
+          gh pr merge "$PR" --squash --delete-branch \
+            --subject 'chore(external-plugins): update external plugin pins'


### PR DESCRIPTION
Makes the external-plugin updater fully hands-off. After the inline `Validate manifest sync` step passes and `create-pull-request` opens the PR, a final step squash-merges it (`gh pr merge --squash --delete-branch`, `chore(external-plugins): ...` subject -> no release).

Why this instead of native auto-merge: GitHub auto-merge needs a blocking requirement to pend on; this repo has no required checks, and a `GITHUB_TOKEN`-authored PR does not trigger `validate.yml` (anti-recursion) - so auto-merge could never arm. The inline sync check (added in #12) is the real gate: a desynced/bad bump fails the workflow and no PR is created.

Tradeoff: no human review of the pin bump. Mitigated by: stable releases only (no prereleases), strict semver, the inline cross-manifest gate, chore = no agent-plugins release, trivially revertible, and the upstream release was already reviewed in its own repo. CI/workflow-only, `ci:` -> no release.