### PR TITLE
chore(external-plugins): add claude-delegator external pin (v1.6.0)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -28,6 +28,19 @@
         "authentication": "ON_INSTALL"
       },
       "category": "Development"
+    },
+    {
+      "name": "claude-delegator",
+      "source": {
+        "source": "url",
+        "url": "git@github.com:antonbabenko/claude-delegator.git",
+        "ref": "v1.6.0"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Development"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -49,6 +49,29 @@
         "tool-disclosure"
       ],
       "version": "0.4.1"
+    },
+    {
+      "name": "claude-delegator",
+      "source": {
+        "source": "github",
+        "repo": "antonbabenko/claude-delegator",
+        "ref": "v1.6.0"
+      },
+      "description": "Use when you want a delegated second opinion or implementation from GPT (Codex) or Gemini - five expert subagents (Architect, Plan Reviewer, Scope Analyst, Code Reviewer, Security Analyst) and bundled ask-gpt/ask-gemini/ask-both/consensus commands, advisory (read-only) or implementation (write).",
+      "category": "development",
+      "keywords": [
+        "delegation",
+        "mcp",
+        "codex",
+        "gpt",
+        "gemini",
+        "experts",
+        "subagents",
+        "orchestration",
+        "code-review",
+        "architecture"
+      ],
+      "version": "1.6.0"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ npx skills add https://github.com/antonbabenko/terraform-skill
 
 /plugin install code-intelligence@antonbabenko
 /plugin install terraform-skill@antonbabenko
+/plugin install claude-delegator@antonbabenko
 ```
 
 ### Codex
@@ -41,7 +42,7 @@ codex plugin marketplace add antonbabenko/agent-plugins
 ```
 
 Then run `codex`, open `/plugins`, select **Agent Plugins**, and install
-`code-intelligence` or `terraform-skill`.
+`code-intelligence`, `terraform-skill`, or `claude-delegator`.
 
 For other hosts, expand below.
 
@@ -203,6 +204,47 @@ Try:
 
 Source and detail: [github.com/antonbabenko/terraform-skill](https://github.com/antonbabenko/terraform-skill).
 The full per-host install list lives in that repo's README.
+
+### [claude-delegator](https://github.com/antonbabenko/claude-delegator)
+
+> Gives the agent five GPT (Codex) and/or Gemini expert subagents - it
+> delegates the hard call (architecture, plan review, scope, code review,
+> security) instead of guessing alone, and synthesizes the result rather than
+> pasting it raw.
+
+**tldr** - what changes with the plugin:
+
+| Prompt | Without the plugin | With the plugin |
+|--------|--------------------|-----------------|
+| Is this auth flow secure? | One model's single take | Security Analyst expert reviews; verdict synthesized, not raw |
+| Review this migration plan | Self-review, same blind spots | Plan Reviewer expert validates before you execute |
+| Get GPT and Gemini to agree on this design | Manual back-and-forth | `consensus` iterates GPT + Gemini + Claude to a signed-off plan |
+
+Each expert runs advisory (read-only) or implementation (`workspace-write`).
+Maintained fork of `jarrodwatts/claude-delegator` (upstream inactive); MIT.
+
+```bash
+/plugin install claude-delegator@antonbabenko
+/claude-delegator:setup
+```
+
+Requires the [Codex CLI](https://github.com/openai/codex) and/or
+[Gemini CLI](https://github.com/google/gemini-cli); `/setup` guides you through
+it.
+
+Bundled commands:
+
+- `/claude-delegator:setup` - configure Codex/Gemini MCP servers + rules
+- `/claude-delegator:uninstall` - remove MCP config, rules, and aliases
+- `/claude-delegator:ask-gpt` - one-shot GPT (Codex) second opinion
+- `/claude-delegator:ask-gemini` - one-shot Gemini second opinion
+- `/claude-delegator:ask-both` - GPT + Gemini in parallel, synthesized
+- `/claude-delegator:consensus` - iterate GPT + Gemini + Claude to consensus
+
+`/setup` can also install short aliases (`/ask-gpt`, `/ask-gemini`,
+`/ask-both`, `/consensus`); opt-in, never overwrites an existing command.
+
+Source and detail: [github.com/antonbabenko/claude-delegator](https://github.com/antonbabenko/claude-delegator).
 
 ## Why these plugins
 

--- a/README.md
+++ b/README.md
@@ -241,6 +241,11 @@ Bundled commands:
 - `/claude-delegator:ask-both` - GPT + Gemini in parallel, synthesized
 - `/claude-delegator:consensus` - iterate GPT + Gemini + Claude to consensus
 
+Use `consensus` when the plan must be right - GPT + Gemini + Claude iterate
+until all three sign off, ideal for high-stakes planning and design. Use the
+`ask-*` commands for a quicker single or parallel opinion when you just want a
+fast second take.
+
 `/setup` can also install short aliases (`/ask-gpt`, `/ask-gemini`,
 `/ask-both`, `/consensus`); opt-in, never overwrites an existing command.
 


### PR DESCRIPTION
Phase 2 + 3: list `claude-delegator` (maintained MIT fork of jarrodwatts/claude-delegator) as an external github-pinned plugin for one-stop discovery. No fork code copied into this Apache-2.0 repo - pin only.

**Phase 2 - manifests**
- `.claude-plugin/marketplace.json`: github source `antonbabenko/claude-delegator` ref `v1.6.0`, mirrored `version: 1.6.0`, keywords, category development.
- `.agents/plugins/marketplace.json`: url source `git@github.com:antonbabenko/claude-delegator.git` ref `v1.6.0`, AVAILABLE/ON_INSTALL.
- Inline manifest-sync gate (in update-external-plugins.yml) verified locally: **in sync OK**. The daily updater resolves github-source entries generically, so future claude-delegator releases auto-bump.

**Phase 3 - README**
- `/plugin install claude-delegator@antonbabenko` added to Claude Code + Codex install blocks.
- New `### claude-delegator` section: one-liner, tldr table, install, requirements (Codex/Gemini CLI), and the full bundled command list (`setup`, `uninstall`, `ask-gpt`, `ask-gemini`, `ask-both`, `consensus`) + opt-in short aliases.

Manifest-only `chore:` + repo-doc change -> no agent-plugins release. JSON valid, ASCII typography, no leaked internal terms (scanned).

Do not merge without owner approval.