### PR TITLE
chore(external-plugins): refresh claude-delegator description (add Grok)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -57,7 +57,7 @@
         "repo": "antonbabenko/claude-delegator",
         "ref": "v1.9.0"
       },
-      "description": "Use when you want a delegated second opinion or implementation from GPT (Codex) or Gemini - five expert subagents (Architect, Plan Reviewer, Scope Analyst, Code Reviewer, Security Analyst) and bundled ask-gpt/ask-gemini/ask-both/consensus commands, advisory (read-only) or implementation (write).",
+      "description": "Use when you want a delegated second opinion or implementation from GPT (Codex), Gemini, or Grok (xAI) - five expert subagents (Architect, Plan Reviewer, Scope Analyst, Code Reviewer, Security Analyst) and bundled ask-gpt/ask-gemini/ask-grok/ask-all/consensus commands, advisory (read-only) or implementation (write; Grok is advisory-only).",
       "category": "development",
       "keywords": [
         "delegation",
@@ -65,6 +65,8 @@
         "codex",
         "gpt",
         "gemini",
+        "grok",
+        "xai",
         "experts",
         "subagents",
         "orchestration",


### PR DESCRIPTION
## What

Refresh the `claude-delegator` listing so it matches the current plugin.

- Description now names all three providers (GPT/Gemini/Grok) instead of just GPT/Gemini.
- Commands corrected: `ask-both` -> `ask-all`, added `ask-grok`.
- Note that Grok is advisory-only.
- Added `grok` and `xai` keywords for discoverability.

## Not changed

`source.ref` and `version` stay at `v1.6.0` / `1.6.0` - the daily
`update-external-plugins` workflow owns those and will bump them once
`claude-delegator` publishes a newer GitHub Release.
