### PR TITLE
chore(marketplace): rename claude-delegator -> deliberation + advertise OpenRouter

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -30,11 +30,11 @@
       "category": "Development"
     },
     {
-      "name": "claude-delegator",
+      "name": "deliberation",
       "source": {
         "source": "url",
-        "url": "git@github.com:antonbabenko/claude-delegator.git",
-        "ref": "v2.0.0"
+        "url": "git@github.com:antonbabenko/deliberation.git",
+        "ref": "v2.0.1"
       },
       "policy": {
         "installation": "AVAILABLE",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -51,29 +51,32 @@
       "version": "0.5.0"
     },
     {
-      "name": "claude-delegator",
+      "name": "deliberation",
       "source": {
         "source": "github",
-        "repo": "antonbabenko/claude-delegator",
-        "ref": "v2.0.0"
+        "repo": "antonbabenko/deliberation",
+        "ref": "v2.0.1"
       },
-      "description": "Use when you want a delegated second opinion or implementation from GPT (Codex), Gemini, or Grok (xAI) - seven expert subagents (Architect, Plan Reviewer, Scope Analyst, Code Reviewer, Security Analyst, Researcher, Debugger) and bundled ask-gpt/ask-gemini/ask-grok/ask-all/consensus commands, advisory (read-only) or implementation (write; Grok is advisory-only).",
+      "description": "Use when you want a delegated second opinion or implementation from GPT (Codex), Gemini, Grok (xAI), or OpenRouter (config-driven, 400+ models) - seven expert subagents (Architect, Plan Reviewer, Scope Analyst, Code Reviewer, Security Analyst, Researcher, Debugger) and bundled ask-gpt/ask-gemini/ask-grok/ask-openrouter/ask-all/consensus commands, advisory (read-only) or implementation (write; Grok and OpenRouter are advisory-only).",
       "category": "development",
       "keywords": [
         "delegation",
         "mcp",
         "codex",
         "gpt",
+        "openai",
         "gemini",
+        "google",
         "grok",
         "xai",
+        "openrouter",
         "experts",
         "subagents",
         "orchestration",
         "code-review",
         "architecture"
       ],
-      "version": "2.0.0"
+      "version": "2.0.1"
     }
   ]
 }

--- a/.kiro/plugins/marketplace.json
+++ b/.kiro/plugins/marketplace.json
@@ -30,11 +30,11 @@
       "category": "Development"
     },
     {
-      "name": "claude-delegator",
+      "name": "deliberation",
       "source": {
         "source": "url",
-        "url": "git@github.com:antonbabenko/claude-delegator.git",
-        "ref": "v2.0.0"
+        "url": "git@github.com:antonbabenko/deliberation.git",
+        "ref": "v2.0.1"
       },
       "policy": {
         "installation": "AVAILABLE",

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ npx skills add https://github.com/antonbabenko/terraform-skill
 
 /plugin install code-intelligence@antonbabenko
 /plugin install terraform-skill@antonbabenko
-/plugin install claude-delegator@antonbabenko
+/plugin install deliberation@antonbabenko
 ```
 
 ### Codex
@@ -42,7 +42,7 @@ codex plugin marketplace add antonbabenko/agent-plugins
 ```
 
 Then run `codex`, open `/plugins`, select **Agent Plugins**, and install
-`code-intelligence`, `terraform-skill`, or `claude-delegator`.
+`code-intelligence`, `terraform-skill`, or `deliberation`.
 
 For other hosts, expand below.
 
@@ -233,12 +233,13 @@ Try:
 Source and detail: [github.com/antonbabenko/terraform-skill](https://github.com/antonbabenko/terraform-skill).
 The full per-host install list lives in that repo's README.
 
-### [claude-delegator](https://github.com/antonbabenko/claude-delegator)
+### [deliberation](https://github.com/antonbabenko/deliberation)
 
-> Gives the agent five GPT (Codex), Gemini, and Grok (xAI) expert subagents - it
-> delegates the hard call (architecture, plan review, scope, code review,
-> security) instead of guessing alone, and synthesizes the result rather than
-> pasting it raw.
+> Gives the agent seven expert subagents - Architect, Plan Reviewer, Scope
+> Analyst, Code Reviewer, Security Analyst, Researcher, Debugger - backed by GPT
+> (Codex), Gemini, Grok (xAI), or OpenRouter. It delegates the hard call
+> (architecture, plan review, scope, code review, security) instead of guessing
+> alone, and synthesizes the result rather than pasting it raw.
 
 **tldr** - what changes with the plugin:
 
@@ -246,35 +247,36 @@ The full per-host install list lives in that repo's README.
 |--------|--------------------|-----------------|
 | Is this auth flow secure? | One model's single take | Security Analyst expert reviews; verdict synthesized, not raw |
 | Review this migration plan | Self-review, same blind spots | Plan Reviewer expert validates before you execute |
-| Get GPT, Gemini, and Grok to agree on this design | Manual back-and-forth | `consensus` runs an arbiter-mediated GPT + Gemini + Grok + Claude loop to a signed-off plan |
+| Get GPT, Gemini, Grok, and OpenRouter to agree on this design | Manual back-and-forth | `consensus` runs an arbiter-mediated GPT + Gemini + Grok + OpenRouter + Claude loop to a signed-off plan |
 
 Each expert runs advisory (read-only) or implementation (`workspace-write`).
 
 ```bash
-/plugin install claude-delegator@antonbabenko
-/claude-delegator:setup
+/plugin install deliberation@antonbabenko
+/deliberation:setup
 ```
 
-Requires at least one provider: [Codex CLI](https://github.com/openai/codex), [~~Gemini~~ Antigravity CLI](https://antigravity.google/docs/gcli-migration), or [Grok (xAI)](https://docs.x.ai/overview); `/setup` guides you through it. Grok is advisory-only (it reviews and votes but cannot change files and write code).
+Requires at least one provider: [Codex CLI](https://github.com/openai/codex), [~~Gemini~~ Antigravity CLI](https://antigravity.google/docs/gcli-migration), [Grok (xAI)](https://docs.x.ai/overview), or [OpenRouter](https://openrouter.ai) (config-driven, 400+ models); `/setup` guides you through it. Grok and OpenRouter are advisory-only (they review and vote but cannot change files and write code).
 
 Bundled commands:
 
 ### 🔥 Magic happens here 🔥
 
-- `/claude-delegator:consensus` - arbiter-mediated GPT + Gemini + Grok + Claude convergence loop. Relentlessly arguing, as if they have nothing else to do!
+- `/deliberation:consensus` - arbiter-mediated GPT + Gemini + Grok + OpenRouter + Claude convergence loop. Relentlessly arguing, as if they have nothing else to do!
 
 ### Ask once
 
-- `/claude-delegator:ask-gpt` - one-shot GPT (Codex) second opinion
-- `/claude-delegator:ask-gemini` - one-shot Gemini second opinion
-- `/claude-delegator:ask-grok` - one-shot Grok (xAI) second opinion (advisory-only)
-- `/claude-delegator:ask-all` - GPT + Gemini + Grok in parallel, synthesized
+- `/deliberation:ask-gpt` - one-shot GPT (Codex) second opinion
+- `/deliberation:ask-gemini` - one-shot Gemini second opinion
+- `/deliberation:ask-grok` - one-shot Grok (xAI) second opinion (advisory-only)
+- `/deliberation:ask-openrouter` - one-shot OpenRouter second opinion (advisory-only, config-driven model)
+- `/deliberation:ask-all` - GPT + Gemini + Grok + OpenRouter in parallel, synthesized
 
 ### Setup and Maintainance
 
-- `/claude-delegator:setup` - configure Codex/Gemini/Grok MCP servers + rules
-- `/claude-delegator:uninstall` - remove MCP config, rules, and aliases
-- `/claude-delegator:grok-files` - list or prune Grok-uploaded files (storage cleanup)
+- `/deliberation:setup` - configure Codex/Gemini/Grok/OpenRouter MCP servers + rules
+- `/deliberation:uninstall` - remove MCP config, rules, and aliases
+- `/deliberation:grok-files` - list or prune Grok-uploaded files (storage cleanup)
 
 Use `consensus` when the plan must be right - the external models vote and
 Claude adjudicates to agreement, ideal for high-stakes planning and design. Use
@@ -282,10 +284,10 @@ the `ask-*` commands for a quicker single or parallel opinion when you just want
 a fast second take.
 
 `/setup` can also install short aliases (`/ask-gpt`, `/ask-gemini`, `/ask-grok`,
-`/ask-all`, `/consensus`, `/grok-files`); opt-in, never overwrites an existing
-command.
+`/ask-openrouter`, `/ask-all`, `/consensus`, `/grok-files`); opt-in, never
+overwrites an existing command.
 
-Source and detail: [github.com/antonbabenko/claude-delegator](https://github.com/antonbabenko/claude-delegator).
+Source and detail: [github.com/antonbabenko/deliberation](https://github.com/antonbabenko/deliberation).
 
 ## Why these plugins
 


### PR DESCRIPTION
## What

Brings the marketplace metadata for the delegation plugin current with two upstream changes:

1. **OpenRouter (already shipped) is now advertised.** The plugin exposes a 4th provider - OpenRouter (config-driven, advisory-only, 400+ models) - and an `ask-openrouter` command. The marketplace description, keywords, and README previously listed only GPT (Codex), Gemini, and Grok (xAI). Also fixes the README expert count (seven, not "five").
2. **Rebrand:** the plugin is renamed `claude-delegator` -> `deliberation` (repo, plugin name, slash namespace). Entry name + source pointers updated across all three manifests; pinned to the planned `v2.0.0` major.

## Files

- `.claude-plugin/marketplace.json` - name, `source.repo`, `ref`/`version` (`v2.0.0`/`2.0.0`), description, keywords (`+openrouter`, `+openai`, `+google`).
- `.agents/plugins/marketplace.json`, `.kiro/plugins/marketplace.json` - name + `source.url` + `ref` (kept in 3-way sync).
- `README.md` - section header/link, provider list, consensus loop, `/deliberation:*` command list (incl. `ask-openrouter`), short aliases.

CI/CD: manifests only. The external-plugin auto-update script auto-discovers from the manifests, so it resolves `antonbabenko/deliberation` automatically once the GitHub rename lands; no script/policy edits needed.

## Why draft - merge checklist

This must not merge until the upstream rename + release exist:

- [ ] upstream `deliberation` `v2.0.0` release published
- [ ] GitHub repo `antonbabenko/claude-delegator` renamed to `antonbabenko/deliberation`
- [ ] confirm the pinned `ref`/`version` (`v2.0.0`) matches the published tag
- [ ] un-draft + merge

## Verification

- 3 manifests parse, are 3-way synced, and satisfy `ref == "v" + version`.
- `markdownlint-cli2 README.md` -> 0 errors.
- `git grep claude-delegator` -> clean (no stale name); expert-count fixed.