### PR TITLE
docs(readme): update antigravity installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,12 +118,13 @@ Update with `git pull` in each clone.
 </details>
 
 <details>
-<summary>Antigravity</summary>
+<summary>Antigravity/Antigravity IDE/Antigravity CLI</summary>
 
 ```bash
-git clone https://github.com/antonbabenko/terraform-skill.git ~/.antigravity/skills/terraform-skill
+git clone https://github.com/antonbabenko/terraform-skill.git
+ln -s "$(pwd)/terraform-skill/skills/terraform-skill" ~/.gemini/config/skills/terraform-skill
 git clone https://github.com/antonbabenko/agent-plugins.git
-ln -s "$(pwd)/agent-plugins/plugins/code-intelligence" ~/.antigravity/skills/code-intelligence
+ln -s "$(pwd)/agent-plugins/plugins/code-intelligence/skills/code-intelligence" ~/.gemini/config/skills/code-intelligence
 ```
 
 Update with `git pull` in each clone.


### PR DESCRIPTION
This PR updates the Antigravity installation instructions in the README to reflect correct paths and naming conventions.

Tested on latest Fedora release 44 with latest Antigravity releases.

[Anigravity 2.0 Documentation](https://antigravity.google/docs/skills)

Loaded plugin in Antigravity
<img width="1036" height="190" alt="image" src="https://github.com/user-attachments/assets/ec23f43d-079b-4711-b513-bc6b433d5173" />

Loaded plugin in Antigravity IDE

<img width="1164" height="411" alt="image" src="https://github.com/user-attachments/assets/8cc4626b-272e-4686-b7da-50bea0c684c4" />

Loaded plugin in Antigravity CLI

<img width="512" height="856" alt="image" src="https://github.com/user-attachments/assets/e976e825-5b21-4f8f-9366-c95f67b7dfb8" />

