### PR TITLE
Fix/build power quoted scalars

### DIFF
--- a/.github/scripts/build_power.py
+++ b/.github/scripts/build_power.py
@@ -26,6 +26,27 @@ import re
 import sys
 
 
+def decode_simple_yaml_scalar(value, field, skill_path):
+    """Decode the single-line quoted scalar forms accepted by SKILL frontmatter."""
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] == '"':
+        try:
+            decoded = json.loads(value)
+        except json.JSONDecodeError as exc:
+            raise SystemExit(
+                f"build_power: {skill_path} frontmatter {field} has invalid "
+                f"double-quoted scalar: {exc.msg}"
+            ) from exc
+        if not isinstance(decoded, str):
+            raise SystemExit(
+                f"build_power: {skill_path} frontmatter {field} must be a string"
+            )
+        return decoded
+    if len(value) >= 2 and value[0] == value[-1] == "'":
+        return value[1:-1].replace("''", "'")
+    return value
+
+
 def parse_frontmatter(skill_path):
     src = open(skill_path, encoding="utf-8").read()
     if not src.startswith("---"):
@@ -38,19 +59,23 @@ def parse_frontmatter(skill_path):
         line = raw.rstrip("\r")
         m = re.match(r"^name:\s*(.+?)\s*$", line)
         if m:
-            out["name"] = m.group(1)
+            out["name"] = decode_simple_yaml_scalar(
+                m.group(1), "name", skill_path)
             continue
         m = re.match(r"^description:\s*(.+?)\s*$", line)
         if m:
-            out["description"] = m.group(1)
+            out["description"] = decode_simple_yaml_scalar(
+                m.group(1), "description", skill_path)
             continue
         m = re.match(r"^\s+author:\s*(.+?)\s*$", line)
         if m:
-            out["author"] = m.group(1)
+            out["author"] = decode_simple_yaml_scalar(
+                m.group(1), "author", skill_path)
             continue
         m = re.match(r"^\s+version:\s*(.+?)\s*$", line)
         if m:
-            out["version"] = m.group(1)
+            out["version"] = decode_simple_yaml_scalar(
+                m.group(1), "version", skill_path)
             continue
     for k in ("name", "description", "author", "version"):
         if not out.get(k):

--- a/.github/scripts/test_build_power.py
+++ b/.github/scripts/test_build_power.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Regression tests for build_power.py frontmatter parsing."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+
+SCRIPT_PATH = Path(__file__).with_name("build_power.py")
+
+
+def load_builder():
+    spec = importlib.util.spec_from_file_location("build_power", SCRIPT_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"unable to load {SCRIPT_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class BuildPowerFrontmatterTests(unittest.TestCase):
+    def _plugin(self, root: Path, frontmatter: str) -> Path:
+        plugin = root / "quoted-skill"
+        skill_dir = plugin / "skills" / "quoted-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            frontmatter + "\n\n# Quoted Skill\n",
+            encoding="utf-8",
+        )
+        codex = plugin / ".codex-plugin"
+        codex.mkdir()
+        (codex / "plugin.json").write_text(
+            json.dumps(
+                {
+                    "interface": {"displayName": "Quoted Skill"},
+                    "keywords": ["quoted", "yaml"],
+                }
+            ),
+            encoding="utf-8",
+        )
+        return plugin
+
+    def test_decodes_quoted_yaml_scalars_before_generating_power(self):
+        builder = load_builder()
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin = self._plugin(
+                Path(tmp),
+                '''---
+name: "quoted-skill"
+description: "Use when: quoted YAML is required"
+metadata:
+  author: 'Example Author'
+  version: "1.2.3"
+---''',
+            )
+
+            generated = builder.build_power(str(plugin))
+
+            self.assertIn('name: "quoted-skill"', generated)
+            self.assertIn('description: "Use when: quoted YAML is required"', generated)
+            self.assertIn('author: "Example Author"', generated)
+            self.assertIn('version: 1.2.3', generated)
+            self.assertNotIn('\\"quoted-skill\\"', generated)
+
+    def test_keeps_existing_unquoted_frontmatter_behavior(self):
+        builder = load_builder()
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin = self._plugin(
+                Path(tmp),
+                '''---
+name: quoted-skill
+description: Use when quoted YAML is not needed
+metadata:
+  author: Example Author
+  version: 1.2.3
+---''',
+            )
+
+            generated = builder.build_power(str(plugin))
+
+            self.assertIn('name: "quoted-skill"', generated)
+            self.assertIn('description: "Use when quoted YAML is not needed"', generated)
+            self.assertIn('author: "Example Author"', generated)
+            self.assertIn('version: 1.2.3', generated)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Pull Request

## Description

**Plugin(s) affected:** <!-- e.g. terraform-skill, or "new plugin: foo" -->

**Type of change:**
- [ ] New plugin
- [ ] New content (best practices, patterns, guidance)
- [ ] Fix (correcting outdated or incorrect information)
- [ ] Refactor (reorganizing or improving clarity)
- [ ] Documentation (README, CONTRIBUTING, CLAUDE.md)
- [ ] CI / tooling

**Summary:**
<!-- What does this change do and why? -->

## Conventional Commit

Releases are per-plugin and driven by the commit scope. The squash/merge
commit subject must be scoped to the plugin:

- `feat(<plugin>): ...` -> minor bump for that plugin
- `fix(<plugin>): ...` -> patch bump
- `feat(<plugin>)!: ...` or `BREAKING CHANGE:` in body -> major bump
- No plugin scope -> no release

**Planned commit subject:** `____(________): ________________`

## Testing Evidence (REQUIRED for content changes)

### Baseline Behavior (WITHOUT changes)

```
Prompt: [test prompt]
Agent response: [verbatim or screenshot]
Issues: [what was missing or incorrect]
```

### Behavior (WITH changes)

```
Prompt: [same test prompt]
Agent response: [verbatim or screenshot]
Improvements: [what improved / patterns now followed]
```

- [ ] Ran the plugin's `tests/baseline-scenarios.md` per its
      `## Running These Tests` (plugin OFF then ON)
- [ ] Every scenario meets its `### Success Criteria`; no scenario fails
- [ ] Added/updated a scenario for any new or changed behavior
- [ ] Agent references new content
- [ ] Agent applies new patterns proactively
- [ ] No new rationalizations introduced

## Standards Compliance Checklist

### Frontmatter (if SKILL.md changed)

- [ ] `name` and `description` present; `name` is letters/numbers/hyphens only
- [ ] Description starts with "Use when..." and is < 1024 chars
- [ ] `metadata.version` (if present) matches the manifest plugin version
      (or left for CI; do not hand-bump)

### Token Efficiency & Content Quality

- [ ] SKILL.md remains lean (target <500 lines)
- [ ] Detailed content lives in `references/*.md`
- [ ] Tables over prose; imperative voice; DO vs DON'T where useful
- [ ] Code examples complete and runnable
- [ ] LLM Consumption Rules in CLAUDE.md followed

### Marketplace / Structure

External plugin (referenced repo):
- [ ] `plugins[]` entry with `source: { source: github, repo: owner/repo, ref: vX.Y.Z }`
- [ ] No local content / CHANGELOG / scoped-commit release
- [ ] `version` (if set) is a manual mirror of `source.ref`

Inline plugin (content here):
- [ ] `plugins[]` entry with `source: ./plugins/<plugin>`
- [ ] `plugins/<plugin>/skills/<plugin>/SKILL.md` exists
- [ ] `plugins/<plugin>/CHANGELOG.md` exists
- [ ] No version numbers hand-edited (CI owns them)

## Validation

<!-- Runs in CI; check locally too (see CLAUDE.md) -->

- [ ] Frontmatter validation passes
- [ ] Manifest <-> SKILL.md version sync passes
- [ ] No broken internal links
- [ ] Markdown lint clean

## Related Issues

Closes #
Relates to #

---

## For Maintainers

- [ ] Testing evidence convincing (baseline -> improved)
- [ ] Standards compliance verified
- [ ] Squash with a correctly scoped conventional commit subject
- [ ] Confirm the resulting per-plugin version bump is intended
